### PR TITLE
Handle case when emojilib returns a object with char null

### DIFF
--- a/emoji-text.js
+++ b/emoji-text.js
@@ -69,7 +69,10 @@ function getMeAnEmoji(keyword) {
         (keywords && keywords.indexOf(keyword) >= 0) ||
         (keywords && keywords.indexOf(maybeSingular) >= 0) ||
         (keywords && keywords.indexOf(maybePlural) >= 0))
-      return allEmojis[emoji].char;
+    {
+      if(allEmojis[emoji].char)  
+        return allEmojis[emoji].char;
+    }    
   }
   return '';
 };


### PR DESCRIPTION
Emojilib return null for words like Github, Octocat etc. Fixed this in my https://github.com/mayankchd/react-text-emoji also.
